### PR TITLE
replace outdates aliases method and fix email relaying

### DIFF
--- a/configs/postfix/main.cf
+++ b/configs/postfix/main.cf
@@ -17,15 +17,15 @@ compatibility_level = 2
 # TLS parameters
 smtpd_tls_cert_file = {TLS_CERT_FILE}
 smtpd_tls_key_file = {TLS_CERT_KEY}
-smtpd_tls_session_cache_database = btree:${data_directory}/smtpd_scache
-smtp_tls_session_cache_database = btree:${data_directory}/smtp_scache
+smtpd_tls_session_cache_database = lmdb:${data_directory}/smtpd_scache
+smtp_tls_session_cache_database = lmdb:${data_directory}/smtp_scache
 smtp_tls_security_level = may
 smtpd_tls_security_level = may
 
 # See /usr/share/doc/postfix/TLS_README.gz in the postfix-doc package for
 # information on enabling SSL in the smtp client.
 
-alias_maps = hash:/etc/aliases
+alias_maps = lmdb:/etc/aliases
 mynetworks = 127.0.0.0/8 [::ffff:127.0.0.0]/104 [::1]/128
 
 # Set your domain here

--- a/configs/postfix/pgsql-relay-domains.cf
+++ b/configs/postfix/pgsql-relay-domains.cf
@@ -5,4 +5,4 @@ password = {POSTGRES_PASSWORD}
 dbname = {POSTGRES_DB}
 
 query = SELECT domain FROM custom_domain WHERE domain='%s' AND verified=true
-    UNION SELECT '%s' WHERE '%s' = '{DOMAIN}' LIMIT 1;
+    UNION SELECT '%s' WHERE '%s' = '{EMAIL_DOMAIN}' LIMIT 1;

--- a/configs/postfix/pgsql-transport-maps.cf
+++ b/configs/postfix/pgsql-transport-maps.cf
@@ -6,4 +6,4 @@ dbname = {POSTGRES_DB}
 
 # forward to smtp:127.0.0.1:20381 for custom domain AND email domain
 query = SELECT 'smtp:127.0.0.1:20381' FROM custom_domain WHERE domain = '%s' AND verified=true
-    UNION SELECT 'smtp:127.0.0.1:20381' WHERE '%s' = '{DOMAIN}' LIMIT 1;
+    UNION SELECT 'smtp:127.0.0.1:20381' WHERE '%s' = '{EMAIL_DOMAIN}' LIMIT 1;

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -30,14 +30,14 @@ then
 fi
 
 hostname=${HOSTNAME-}
-domain=${EMAIL_DOMAIN-}
+email_domain=${EMAIL_DOMAIN-}
 
 if [ -z ${hostname} ];
 then
   echo "ERROR: HOSTNAME unset";
   exit
 fi
-if [ -z ${domain} ];
+if [ -z ${email_domain} ];
 then
   echo "ERROR: EMAIL_DOMAIN unset";
   exit
@@ -63,7 +63,7 @@ fi
 echo "creating postfix configs"
 
 sed -i "s/{HOSTNAME}/$hostname/" /etc/postfix/main.cf
-sed -i "s/{EMAIL_DOMAIN}/$domain/" /etc/postfix/main.cf
+sed -i "s/{EMAIL_DOMAIN}/$email_domain/" /etc/postfix/main.cf
 sed -i "s/{TLS_CERT_FILE}/$tls_cert_file/" /etc/postfix/main.cf
 sed -i "s/{TLS_CERT_KEY}/$tls_cert_key/" /etc/postfix/main.cf
 
@@ -71,13 +71,13 @@ sed -i "s/{POSTGRES_HOST}/$pg_host/" /etc/postfix/pgsql-relay-domains.cf
 sed -i "s/{POSTGRES_USER}/$pg_user/" /etc/postfix/pgsql-relay-domains.cf
 sed -i "s/{POSTGRES_PASSWORD}/$pg_password/" /etc/postfix/pgsql-relay-domains.cf
 sed -i "s/{POSTGRES_DB}/$pg_db/" /etc/postfix/pgsql-relay-domains.cf
-sed -i "s/{EMAIL_DOMAIN}/$domain/" /etc/postfix/pgsql-relay-domains.cf
+sed -i "s/{EMAIL_DOMAIN}/$email_domain/" /etc/postfix/pgsql-relay-domains.cf
 
 sed -i "s/{POSTGRES_HOST}/$pg_host/" /etc/postfix/pgsql-transport-maps.cf
 sed -i "s/{POSTGRES_USER}/$pg_user/" /etc/postfix/pgsql-transport-maps.cf
 sed -i "s/{POSTGRES_PASSWORD}/$pg_password/" /etc/postfix/pgsql-transport-maps.cf
 sed -i "s/{POSTGRES_DB}/$pg_db/" /etc/postfix/pgsql-transport-maps.cf
-sed -i "s/{EMAIL_DOMAIN}/$domain/" /etc/postfix/pgsql-transport-maps.cf
+sed -i "s/{EMAIL_DOMAIN}/$email_domain/" /etc/postfix/pgsql-transport-maps.cf
 
 echo "waiting for postgres to be ready..."
 while ! nc -z ${POSTGRES_HOST} ${POSTGRES_PORT:-5432}; do

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -89,5 +89,8 @@ done
 DB_URI=postgresql://${POSTGRES_USER}:${POSTGRES_PASSWORD}@${POSTGRES_HOST}:${POSTGRES_PORT:-5432}/${POSTGRES_DB} alembic upgrade head
 DB_URI=postgresql://${POSTGRES_USER}:${POSTGRES_PASSWORD}@${POSTGRES_HOST}:${POSTGRES_PORT:-5432}/${POSTGRES_DB} python init_app.py
 
+# create empty postfix aliases
+touch /etc/aliases && postalias /etc/aliases
+
 echo "starting simplelogin"
 DB_URI=postgresql://${POSTGRES_USER}:${POSTGRES_PASSWORD}@${POSTGRES_HOST}:${POSTGRES_PORT:-5432}/${POSTGRES_DB} /usr/bin/supervisord -c /etc/supervisor/conf.d/supervisord.conf


### PR DESCRIPTION
This PR contains various changes to fix email relaying:
- replaced btree and hash postfix aliases with lmdb fixed #8
- changed `DOMAIN` with `EMAIL_DOMAIN` in postfix postgres query to fix the error with emails that are rejected